### PR TITLE
Put Networking impls back onto-thread

### DIFF
--- a/src/main/java/com/github/nyuppo/MoreMobVariants.java
+++ b/src/main/java/com/github/nyuppo/MoreMobVariants.java
@@ -69,46 +69,48 @@ public class MoreMobVariants implements ModInitializer {
         // Server event to respond to client request for a variant
         ServerPlayNetworking.registerGlobalReceiver(MMVNetworkingConstants.CLIENT_REQUEST_VARIANT_ID, ((server, player, handler, buf, responseSender) -> {
             UUID uuid = buf.readUuid();
-            Entity entity = server.getOverworld().getEntity(uuid);
+            server.execute( () -> {
+                Entity entity = server.getOverworld().getEntity(uuid);
 
-            // If we couldn't find the mob in the overworld, start checking all other worlds
-            if (entity == null) {
-                for (ServerWorld serverWorld : server.getWorlds()) {
-                    Entity entity2 = serverWorld.getEntity(uuid);
-                    if (entity2 != null) {
-                        entity = entity2;
+                // If we couldn't find the mob in the overworld, start checking all other worlds
+                if (entity == null) {
+                    for (ServerWorld serverWorld : server.getWorlds()) {
+                        Entity entity2 = serverWorld.getEntity(uuid);
+                        if (entity2 != null) {
+                            entity = entity2;
+                        }
                     }
                 }
-            }
 
-            if (entity != null) {
-                NbtCompound nbt = new NbtCompound();
-                entity.writeNbt(nbt);
+                if (entity != null) {
+                    NbtCompound nbt = new NbtCompound();
+                    entity.writeNbt(nbt);
 
-                if (nbt.contains(NBT_KEY)) {
-                    PacketByteBuf responseBuf = PacketByteBufs.create();
-                    responseBuf.writeInt(entity.getId());
-                    responseBuf.writeString(nbt.getString(NBT_KEY));
+                    if (nbt.contains(NBT_KEY)) {
+                        PacketByteBuf responseBuf = PacketByteBufs.create();
+                        responseBuf.writeInt(entity.getId());
+                        responseBuf.writeString(nbt.getString(NBT_KEY));
 
-                    // For some reason, "Sitting" syncing breaks, so send that too I guess
-                    if (entity instanceof TameableEntity) {
-                        responseBuf.writeBoolean(nbt.getBoolean("Sitting"));
+                        // For some reason, "Sitting" syncing breaks, so send that too I guess
+                        if (entity instanceof TameableEntity) {
+                            responseBuf.writeBoolean(nbt.getBoolean("Sitting"));
+                        }
+
+                        // Muddy pigs
+                        if (entity instanceof PigEntity) {
+                            responseBuf.writeBoolean(nbt.getBoolean(MUDDY_NBT_KEY));
+                            responseBuf.writeInt(nbt.getInt(MUDDY_TIMEOUT_NBT_KEY));
+                        }
+
+                        // Sheep horns
+                        if (entity instanceof SheepEntity) {
+                            responseBuf.writeString(nbt.getString(SHEEP_HORN_COLOUR_NBT_KEY));
+                        }
+
+                        ServerPlayNetworking.send(handler.getPlayer(), MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, responseBuf);
                     }
-
-                    // Muddy pigs
-                    if (entity instanceof PigEntity) {
-                        responseBuf.writeBoolean(nbt.getBoolean(MUDDY_NBT_KEY));
-                        responseBuf.writeInt(nbt.getInt(MUDDY_TIMEOUT_NBT_KEY));
-                    }
-
-                    // Sheep horns
-                    if (entity instanceof SheepEntity) {
-                        responseBuf.writeString(nbt.getString(SHEEP_HORN_COLOUR_NBT_KEY));
-                    }
-
-                    ServerPlayNetworking.send(handler.getPlayer(), MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, responseBuf);
                 }
-            }
+            });
         }));
     }
 

--- a/src/main/java/com/github/nyuppo/MoreMobVariants.java
+++ b/src/main/java/com/github/nyuppo/MoreMobVariants.java
@@ -91,21 +91,29 @@ public class MoreMobVariants implements ModInitializer {
                         responseBuf.writeInt(entity.getId());
                         responseBuf.writeString(nbt.getString(NBT_KEY));
 
+                        //going to pass all three of these regardless, so buf structure is constant. More cases can be added and hook into these as needed.
+                        boolean bl = false;
+                        int i = 0;
+                        String str = "";
+
                         // For some reason, "Sitting" syncing breaks, so send that too I guess
                         if (entity instanceof TameableEntity) {
-                            responseBuf.writeBoolean(nbt.getBoolean("Sitting"));
+                            bl = nbt.getBoolean("Sitting");
                         }
 
                         // Muddy pigs
                         if (entity instanceof PigEntity) {
-                            responseBuf.writeBoolean(nbt.getBoolean(MUDDY_NBT_KEY));
-                            responseBuf.writeInt(nbt.getInt(MUDDY_TIMEOUT_NBT_KEY));
+                            bl = nbt.getBoolean(MUDDY_NBT_KEY);
+                            i = nbt.getInt(MUDDY_TIMEOUT_NBT_KEY);
                         }
 
                         // Sheep horns
                         if (entity instanceof SheepEntity) {
-                            responseBuf.writeString(nbt.getString(SHEEP_HORN_COLOUR_NBT_KEY));
+                            str = nbt.getString(SHEEP_HORN_COLOUR_NBT_KEY);
                         }
+                        responseBuf.writeBoolean(bl);
+                        responseBuf.writeVarInt(i);
+                        responseBuf.writeString(str);
 
                         ServerPlayNetworking.send(handler.getPlayer(), MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, responseBuf);
                     }

--- a/src/main/java/com/github/nyuppo/MoreMobVariantsClient.java
+++ b/src/main/java/com/github/nyuppo/MoreMobVariantsClient.java
@@ -57,42 +57,43 @@ public class MoreMobVariantsClient implements ClientModInitializer {
         ClientPlayNetworking.registerGlobalReceiver(MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, ((client, handler, buf, responseSender) -> {
             int id = buf.readInt();
             String variantId = buf.readString();
+            client.execute(() -> {
+                if (client.world != null) {
+                    Entity entity = client.world.getEntityById(id);
+                    if (entity != null) {
+                        NbtCompound nbt = new NbtCompound();
+                        entity.writeNbt(nbt);
 
-            if (client.world != null) {
-                Entity entity = client.world.getEntityById(id);
-                if (entity != null) {
-                    NbtCompound nbt = new NbtCompound();
-                    entity.writeNbt(nbt);
+                        nbt.putString(MoreMobVariants.NBT_KEY, variantId);
 
-                    nbt.putString(MoreMobVariants.NBT_KEY, variantId);
+                        // For some reason, "Sitting" syncing breaks, so get that too I guess
+                        if (entity instanceof TameableEntity) {
+                            nbt.putBoolean("Sitting", buf.readBoolean());
+                        }
 
-                    // For some reason, "Sitting" syncing breaks, so get that too I guess
-                    if (entity instanceof TameableEntity) {
-                        nbt.putBoolean("Sitting", buf.readBoolean());
+                        // Muddy pigs
+                        boolean isMuddy;
+                        int muddyTimeLeft;
+                        if (entity instanceof PigEntity) {
+                            isMuddy = buf.readBoolean();
+                            muddyTimeLeft = buf.readInt();
+
+                            nbt.putBoolean(MoreMobVariants.MUDDY_NBT_KEY, isMuddy);
+                            nbt.putInt(MoreMobVariants.MUDDY_TIMEOUT_NBT_KEY, muddyTimeLeft);
+                        }
+
+                        // Sheep horns
+                        String hornColour;
+                        if (entity instanceof SheepEntity) {
+                            hornColour = buf.readString();
+
+                            nbt.putString(MoreMobVariants.SHEEP_HORN_COLOUR_NBT_KEY, hornColour);
+                        }
+
+                        entity.readNbt(nbt);
                     }
-
-                    // Muddy pigs
-                    boolean isMuddy;
-                    int muddyTimeLeft;
-                    if (entity instanceof PigEntity) {
-                        isMuddy = buf.readBoolean();
-                        muddyTimeLeft = buf.readInt();
-
-                        nbt.putBoolean(MoreMobVariants.MUDDY_NBT_KEY, isMuddy);
-                        nbt.putInt(MoreMobVariants.MUDDY_TIMEOUT_NBT_KEY, muddyTimeLeft);
-                    }
-
-                    // Sheep horns
-                    String hornColour;
-                    if (entity instanceof SheepEntity) {
-                        hornColour = buf.readString();
-
-                        nbt.putString(MoreMobVariants.SHEEP_HORN_COLOUR_NBT_KEY, hornColour);
-                    }
-
-                    entity.readNbt(nbt);
                 }
-            }
+            });
         }));
     }
 

--- a/src/main/java/com/github/nyuppo/MoreMobVariantsClient.java
+++ b/src/main/java/com/github/nyuppo/MoreMobVariantsClient.java
@@ -57,6 +57,10 @@ public class MoreMobVariantsClient implements ClientModInitializer {
         ClientPlayNetworking.registerGlobalReceiver(MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, ((client, handler, buf, responseSender) -> {
             int id = buf.readInt();
             String variantId = buf.readString();
+            //read all three buffer values regardless, in the Netty loop. use as needed in the client.
+            boolean bl = buf.readBoolean();
+            int i = buf.readVarInt();
+            String str = buf.readString();
             client.execute(() -> {
                 if (client.world != null) {
                     Entity entity = client.world.getEntityById(id);
@@ -68,15 +72,15 @@ public class MoreMobVariantsClient implements ClientModInitializer {
 
                         // For some reason, "Sitting" syncing breaks, so get that too I guess
                         if (entity instanceof TameableEntity) {
-                            nbt.putBoolean("Sitting", buf.readBoolean());
+                            nbt.putBoolean("Sitting",bl);
                         }
 
                         // Muddy pigs
                         boolean isMuddy;
                         int muddyTimeLeft;
                         if (entity instanceof PigEntity) {
-                            isMuddy = buf.readBoolean();
-                            muddyTimeLeft = buf.readInt();
+                            isMuddy = bl;
+                            muddyTimeLeft = i;
 
                             nbt.putBoolean(MoreMobVariants.MUDDY_NBT_KEY, isMuddy);
                             nbt.putInt(MoreMobVariants.MUDDY_TIMEOUT_NBT_KEY, muddyTimeLeft);
@@ -85,7 +89,7 @@ public class MoreMobVariantsClient implements ClientModInitializer {
                         // Sheep horns
                         String hornColour;
                         if (entity instanceof SheepEntity) {
-                            hornColour = buf.readString();
+                            hornColour = str;
 
                             nbt.putString(MoreMobVariants.SHEEP_HORN_COLOUR_NBT_KEY, hornColour);
                         }

--- a/src/main/java/com/github/nyuppo/MoreMobVariantsClient.java
+++ b/src/main/java/com/github/nyuppo/MoreMobVariantsClient.java
@@ -53,7 +53,25 @@ public class MoreMobVariantsClient implements ClientModInitializer {
             }
         });
 
-        // Client event to handle response from server about mob variant
+        // Client event to handle response from server about basic mob variants
+        ClientPlayNetworking.registerGlobalReceiver(MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, ((client, handler, buf, responseSender) -> {
+            int id = buf.readInt();
+            String variantId = buf.readString();
+            client.execute(() -> {
+                if (client.world != null) {
+                    Entity entity = client.world.getEntityById(id);
+                    if (entity != null) {
+                        NbtCompound nbt = new NbtCompound();
+                        entity.writeNbt(nbt);
+                        nbt.putString(MoreMobVariants.NBT_KEY, variantId);
+                        entity.readNbt(nbt);
+                    }
+                }
+            });
+        }));
+
+
+        // Client event to handle response from server about complex mob variants
         ClientPlayNetworking.registerGlobalReceiver(MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, ((client, handler, buf, responseSender) -> {
             int id = buf.readInt();
             String variantId = buf.readString();

--- a/src/main/java/com/github/nyuppo/mixin/CatVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/CatVariantsMixin.java
@@ -57,7 +57,7 @@ public class CatVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }
@@ -92,5 +92,3 @@ public class CatVariantsMixin extends MobEntityVariantsMixin {
         child.readCustomDataFromNbt(childNbt);
     }
 }
-
-

--- a/src/main/java/com/github/nyuppo/mixin/ChickenVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/ChickenVariantsMixin.java
@@ -57,7 +57,7 @@ public abstract class ChickenVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }

--- a/src/main/java/com/github/nyuppo/mixin/CowVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/CowVariantsMixin.java
@@ -55,7 +55,7 @@ public abstract class CowVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }

--- a/src/main/java/com/github/nyuppo/mixin/PigVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/PigVariantsMixin.java
@@ -62,8 +62,10 @@ public abstract class PigVariantsMixin extends MobEntityVariantsMixin {
                 PacketByteBuf updateBuf = PacketByteBufs.create();
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
+                //all three values in the "regular" packet post update
                 updateBuf.writeBoolean(isMuddy);
-                updateBuf.writeInt(muddyTimeLeft);
+                updateBuf.writeVarInt(muddyTimeLeft);
+                updateBuf.writeString("");
 
                 ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
             });

--- a/src/main/java/com/github/nyuppo/mixin/SheepVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/SheepVariantsMixin.java
@@ -60,6 +60,9 @@ public abstract class SheepVariantsMixin extends MobEntityVariantsMixin {
                 PacketByteBuf updateBuf = PacketByteBufs.create();
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
+                //all three values in the "regular" packet post update
+                updateBuf.writeBoolean(false);
+                updateBuf.writeVarInt(0);
                 updateBuf.writeString(hornColour);
 
                 ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);

--- a/src/main/java/com/github/nyuppo/mixin/SkeletonVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/SkeletonVariantsMixin.java
@@ -53,7 +53,7 @@ public class SkeletonVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }

--- a/src/main/java/com/github/nyuppo/mixin/SpiderVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/SpiderVariantsMixin.java
@@ -53,7 +53,7 @@ public class SpiderVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }

--- a/src/main/java/com/github/nyuppo/mixin/WolfVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/WolfVariantsMixin.java
@@ -57,7 +57,7 @@ public class WolfVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }

--- a/src/main/java/com/github/nyuppo/mixin/ZombieVariantsMixin.java
+++ b/src/main/java/com/github/nyuppo/mixin/ZombieVariantsMixin.java
@@ -53,7 +53,7 @@ public class ZombieVariantsMixin extends MobEntityVariantsMixin {
                 updateBuf.writeInt(((Entity)(Object)this).getId());
                 updateBuf.writeString(variant.getIdentifier().toString());
 
-                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_VARIANT_ID, updateBuf);
+                ServerPlayNetworking.send(player, MMVNetworkingConstants.SERVER_RESPOND_BASIC_VARIANT_ID, updateBuf);
             });
         }
     }

--- a/src/main/java/com/github/nyuppo/networking/MMVNetworkingConstants.java
+++ b/src/main/java/com/github/nyuppo/networking/MMVNetworkingConstants.java
@@ -6,4 +6,5 @@ import net.minecraft.util.Identifier;
 public class MMVNetworkingConstants {
     public static final Identifier CLIENT_REQUEST_VARIANT_ID = MoreMobVariants.id("client_request");
     public static final Identifier SERVER_RESPOND_VARIANT_ID = MoreMobVariants.id("server_respond");
+    public static final Identifier SERVER_RESPOND_BASIC_VARIANT_ID = MoreMobVariants.id("server_respond_basic");
 }


### PR DESCRIPTION
fixes: #30 

## Proposed changes
* Add `server.execute()` wrapper around impl in the `MoreMobVariants` call to `registerGlobalReceiver`
* Add `client.execute()` wrapper around impl in the `MoreMobVariantsClient` call to `registerGlobalReceiver`

## Reasoning
Networking happens in it's own collection of Netty Event Loop threads, not on the main Render and Server threads. As such, any interaction with Minecraft itself inside networking is off-thread. `execute()` queues a task with the server/client to run the code inside it on-thread when it's able.